### PR TITLE
n-body: fix computation of acceleration

### DIFF
--- a/examples/n-body/Common/World.hs
+++ b/examples/n-body/Common/World.hs
@@ -35,9 +35,7 @@ advanceBodies calcAccels timeStep bodies
                         $ A.map pointMassOfBody bodies
 
         -- Apply the accelerations to the bodies and advance them
-        advance b a     = let m         = massOfPointMass (pointMassOfBody b)
-                              a'        = m *^ a
-                          in advanceBody (the timeStep) (setAccelOfBody a' b)
+        advance b a     = advanceBody (the timeStep) (setAccelOfBody a b)
     in
     A.zipWith advance bodies accels
 


### PR DESCRIPTION
As described in https://github.com/AccelerateHS/accelerate/issues/458 , I believe that the multiplication of mass is unnecessary and incorrect. Correct me if I am wrong, though.